### PR TITLE
Added or_tags to UserSegment.cs (#476)

### DIFF
--- a/src/ZendeskApi_v2/Models/UserSegments/UserSegment.cs
+++ b/src/ZendeskApi_v2/Models/UserSegments/UserSegment.cs
@@ -31,6 +31,9 @@ namespace ZendeskApi_v2.Models.UserSegments
         [JsonProperty("tags")]
         public IList<string> Tags { get; set; }
 
+        [JsonProperty("or_tags")]
+        public IList<string> OrTags { get; set; }
+
         [JsonProperty("created_at")]
         public string CreatedAt { get; set; }
 

--- a/test/ZendeskApi_v2.Test/HelpCenter/UserSegmentTests.cs
+++ b/test/ZendeskApi_v2.Test/HelpCenter/UserSegmentTests.cs
@@ -1,11 +1,9 @@
-﻿using System.Threading.Tasks;
-using Newtonsoft.Json;
+﻿using System.Linq;
+using System.Threading.Tasks;
 using NUnit.Framework;
 using ZendeskApi_v2;
 using ZendeskApi_v2.Models.HelpCenter.Topics;
-using ZendeskApi_v2.Models.Sections;
 using ZendeskApi_v2.Models.UserSegments;
-using ZendeskApi_v2.Requests.HelpCenter;
 
 namespace Tests.HelpCenter
 {
@@ -102,6 +100,17 @@ namespace Tests.HelpCenter
 
             var res = api.HelpCenter.UserSegments.GetUserSegmentsByUserId(Settings.UserId);
             Assert.That(res.UserSegments.Count, Is.GreaterThan(0));
+        }
+
+        [Test]
+        public void CanRetrieveUserSegmentOrTags()
+        {
+            var res = api.HelpCenter.UserSegments.GetUserSegments().UserSegments;
+            var segment = res.First(seg => seg.Name == "Agents and managers (or_tags: tag1, tag2)");
+
+            Assert.That(segment.OrTags.Count == 2);
+            Assert.That(segment.OrTags.Contains("tag1"));
+            Assert.That(segment.OrTags.Contains("tag2"));
         }
 
         [Test]


### PR DESCRIPTION
* Added or_tags to UserSegment.cs

This supports the criterion where a user or organization has to match ANY of the tags in the list found in the or_tags property of the user segment response

* Added unit test to check that or_tags are correctly retrieved in user segment response